### PR TITLE
Update docker-compose to avoid errors

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ sleepy-puppy-web:
   volumes:
     - /usr/local/src/sleepy-puppy/sleepypuppy/static
   environment:
-    DEBUG: False
+    # DEBUG: False
     sleepypuppy_db: postgresql://postgres:password@postgres/sleepypuppydb
     secret_key: 5(15ds+i2+%ik6z&!yer+ga9m=e%jcqiz_5wszg)r-z!2--b2d
     csrf_session_key: 5(18ds+i2+%ik6z&!yer+ga9m=e%jcqiz_5wszg)r-z!2--b2d


### PR DESCRIPTION
Update docker-compose.

This fix the following:

~~~
jbono@MacBook [~/sleepy-puppy-docker]> docker-compose up
ERROR: The Compose file './docker-compose.yml' is invalid because:
sleepy-puppy-web.environment.DEBUG contains false, which is an invalid type, it should be a string, number, or a null
~~~